### PR TITLE
Transformation 3: Rotation fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ dependencies {
     compile group: 'org.graphstream', name: 'gs-algo', version: '1.3'
     compile group: 'org.javatuples', name: 'javatuples', version: '1.2'
 
+    testCompile("org.junit.jupiter:junit-jupiter-params:5.4.2")
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.4.2'
     testRuntime(
             'org.junit.jupiter:junit-jupiter-engine:5.4.2',

--- a/src/main/java/model/ModelGraph.java
+++ b/src/main/java/model/ModelGraph.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ModelGraph extends MultiGraph {
 
@@ -131,12 +132,16 @@ public class ModelGraph extends MultiGraph {
         return Optional.ofNullable(edges.get(id));
     }
 
-    public Optional<Vertex> getVertexBetween(Vertex beginning, Vertex end) {
+    public List<Vertex> getVertexesBetween(Vertex beginning, Vertex end) {
         return this.vertexes
                 .values()
                 .stream()
                 .filter(v -> isVertexBetween(v, beginning, end))
-                .findFirst();
+                .collect(Collectors.toList());
+    }
+
+    public Optional<Vertex> getVertexBetween(Vertex beginning, Vertex end) {
+        return this.getVertexesBetween(beginning, end).stream().findFirst();
     }
 
     public GraphEdge getTraingleLongestEdge(InteriorNode interiorNode){

--- a/src/main/java/transformation/TransformationP3.java
+++ b/src/main/java/transformation/TransformationP3.java
@@ -3,12 +3,14 @@ package transformation;
 import model.*;
 import org.javatuples.Triplet;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 public class TransformationP3 implements Transformation {
     @Override
     public boolean isConditionCompleted(ModelGraph graph, InteriorNode interiorNode) {
-        Triplet<Vertex, Vertex, Vertex> triangle = interiorNode.getTriangleVertexes();
+        Triplet<Vertex, Vertex, Vertex> triangle = getOrderedTriangle(interiorNode.getTriangleVertexes(), graph);
 
         return areAllVertexType(triangle) &&
                 isTransformationConditionFulfilled(graph, triangle);
@@ -16,7 +18,7 @@ public class TransformationP3 implements Transformation {
 
     @Override
     public ModelGraph transformGraph(ModelGraph graph, InteriorNode interiorNode) {
-        Triplet<Vertex, Vertex, Vertex> triangle = getOrderedTriage(interiorNode.getTriangleVertexes(), graph);
+        Triplet<Vertex, Vertex, Vertex> triangle = getOrderedTriangle(interiorNode.getTriangleVertexes(), graph);
 
         Vertex first = triangle.getValue0();
         Vertex second = triangle.getValue1();
@@ -59,13 +61,12 @@ public class TransformationP3 implements Transformation {
     }
 
     private Optional<Vertex> getHangingVertexBetweenOp(Vertex v1, Vertex v2, ModelGraph graph){
-        Optional<Vertex> between = graph.getVertexBetween(v1, v2);
-        
-        if(between.isPresent() && between.get().getVertexType() == VertexType.HANGING_NODE){
-            return between;
-        }
+        List<Vertex> available = graph.getVertexesBetween(v1, v2);
 
-        return Optional.empty();
+        return available
+                .stream()
+                .filter(vertex -> vertex.getVertexType() == VertexType.HANGING_NODE)
+                .findAny();
     }
 
     private Vertex getHangingVertexBetween(Vertex v1, Vertex v2, ModelGraph graph){
@@ -87,7 +88,7 @@ public class TransformationP3 implements Transformation {
         return (L1.getL() + L2.getL()) >= L3.getL() && (L1.getL() + L2.getL()) >= L4.getL();
     }
 
-    private Triplet<Vertex, Vertex, Vertex> getOrderedTriage(Triplet<Vertex, Vertex, Vertex> v, ModelGraph graph){
+    private Triplet<Vertex, Vertex, Vertex> getOrderedTriangle(Triplet<Vertex, Vertex, Vertex> v, ModelGraph graph){
         if(getHangingVertexBetweenOp(v.getValue0(), v.getValue1(), graph).isPresent()){
             return v;
         } else if (getHangingVertexBetweenOp(v.getValue0(), v.getValue2(), graph).isPresent()){

--- a/src/test/java/AbstractTransformationTest.java
+++ b/src/test/java/AbstractTransformationTest.java
@@ -27,7 +27,7 @@ public class AbstractTransformationTest {
         return graph;
     }
 
-    public ModelGraph createEmptyGraph() {
+    public static ModelGraph createEmptyGraph() {
         return new ModelGraph("testGraph");
     }
 }

--- a/src/test/java/TransformationP3Test.java
+++ b/src/test/java/TransformationP3Test.java
@@ -1,0 +1,112 @@
+import model.*;
+import org.javatuples.Triplet;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import transformation.Transformation;
+import transformation.TransformationP3;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class TransformationP3Test extends AbstractTransformationTest {
+    private Transformation transformation = new TransformationP3();
+
+    @ParameterizedTest
+    @MethodSource("graphs")
+    public void transformationProducesTwoInteriorNodes(Triplet<ModelGraph, InteriorNode, Vertex> graph) {
+        // Arrange
+        assertEquals(1, graph.getValue0().getInteriors().size());
+
+        // Act
+        ModelGraph result = transformation.transformGraph(graph.getValue0(), graph.getValue1());
+
+        // Assert
+        assertEquals(2, result.getInteriors().size());
+    }
+
+    @ParameterizedTest
+    @MethodSource("graphs")
+    public void hangingBecomesSimpleNode(Triplet<ModelGraph, InteriorNode, Vertex> graph) {
+        // Arrange
+        assertEquals(1, graph.getValue0().getInteriors().size());
+
+        // Act
+        transformation.transformGraph(graph.getValue0(), graph.getValue1());
+
+        // Assert
+        assertEquals(VertexType.SIMPLE_NODE, graph.getValue2().getVertexType());
+    }
+
+    @ParameterizedTest
+    @MethodSource("graphs")
+    public void hasNoHangingNode(Triplet<ModelGraph, InteriorNode, Vertex> graph) {
+        // Arrange
+        assertEquals(1, graph.getValue0().getInteriors().size());
+
+        // Act
+        ModelGraph result = transformation.transformGraph(graph.getValue0(), graph.getValue1());
+
+        // Assert
+        assertEquals(0, result.getVertices().stream()
+                .filter(e -> e.getVertexType().equals(VertexType.HANGING_NODE))
+                .count());
+    }
+
+    private static Stream<Triplet<ModelGraph, InteriorNode, Vertex>> graphs()
+    {
+        return Stream.of(
+                createGraph(),
+                createGraph1(),
+                createGraph2()
+        );
+    }
+
+    private static Triplet<ModelGraph, InteriorNode, Vertex> createGraph() {
+        ModelGraph graph = createEmptyGraph();
+        Vertex v1 = graph.insertVertex("v1", VertexType.SIMPLE_NODE, new Point3d(0.0, 0.0, 0.0));
+        Vertex v2 = graph.insertVertex("v2", VertexType.SIMPLE_NODE, new Point3d(2.0, 0.0, 0.0));
+        Vertex v3 = graph.insertVertex("v3", VertexType.SIMPLE_NODE, new Point3d(1.0, 1.0, 0.0));
+        Vertex h4 = graph.insertVertex("h4", VertexType.HANGING_NODE, new Point3d(1.5, 0.5, 0.0));
+
+        GraphEdge v2_h4 = graph.insertEdge("e1", v2, h4, true);
+        GraphEdge v1_v3 = graph.insertEdge("e2", v1, v3, true);
+        GraphEdge h4_v3 = graph.insertEdge("e3", h4, v3, true);
+        GraphEdge v2_v3 = graph.insertEdge("e4", v2, v3, true);
+
+        InteriorNode in1 = graph.insertInterior("i1", v1, v2, v3);
+        return new Triplet<>(graph, in1, h4);
+    }
+
+    private static Triplet<ModelGraph, InteriorNode, Vertex> createGraph1() {
+        ModelGraph graph = new ModelGraph("testGraph");
+        Vertex v1 = graph.insertVertex("v1", VertexType.SIMPLE_NODE, new Point3d(0.0, 0.0, 0.0));
+        Vertex v2 = graph.insertVertex("v2", VertexType.SIMPLE_NODE, new Point3d(5.0, 0.0, 0.0));
+        Vertex v3 = graph.insertVertex("v3", VertexType.SIMPLE_NODE, new Point3d(0.0, 5.0, 0.0));
+        Vertex h4 = graph.insertVertex("h4", VertexType.HANGING_NODE, new Point3d(2.5, 2.5, 0.0));
+
+        GraphEdge v2_h4 = graph.insertEdge("e1", v2, h4, true);
+        GraphEdge v1_v3 = graph.insertEdge("e2", v1, v3, true);
+        GraphEdge h4_v3 = graph.insertEdge("e3", h4, v3, true);
+        GraphEdge v1_v2 = graph.insertEdge("e5", v1, v2, true);
+
+        InteriorNode in1 = graph.insertInterior("i1", v1, v2, v3);
+        return new Triplet<>(graph, in1, h4);
+    }
+
+    private static Triplet<ModelGraph, InteriorNode, Vertex> createGraph2(){
+        ModelGraph graph = new ModelGraph("testGraph");
+        Vertex v1 = graph.insertVertex("v1", VertexType.SIMPLE_NODE, new Point3d(0.0, 0.0, 0.0));
+        Vertex v2 = graph.insertVertex("v2", VertexType.SIMPLE_NODE, new Point3d(5.0, 0.0, 0.0));
+        Vertex v3 = graph.insertVertex("v3", VertexType.SIMPLE_NODE, new Point3d(5.0, 5.0, 0.0));
+        Vertex h4 = graph.insertVertex("h4", VertexType.HANGING_NODE, new Point3d(2.5, 2.5, 0.0));
+
+        GraphEdge v1_v2 = graph.insertEdge("e1", v1, v2, true);
+        GraphEdge v2_v3 = graph.insertEdge("e2", v2, v3, true);
+        GraphEdge v1_h4 = graph.insertEdge("e3", v1, h4, true);
+        GraphEdge h4_v3 = graph.insertEdge("e4", h4, v3, true);
+
+        InteriorNode in1 = graph.insertInterior("i1", v1, v2, v3);
+        return new Triplet<>(graph, in1, h4);
+    }
+}


### PR DESCRIPTION
During the demo there were some issues with rotation in Transformation 3 caused by the bug in `getVertexBetween`. In order to not break the API i've created a method `getVertexesBetween` that returns all vertexes (not just one, which was the issue)